### PR TITLE
Fix a bug with CTRL+ENTER and an empty string input

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,8 @@
         },
         methods: {
             createTask() {
+                if (!this.newTaskText) return
+
                 this.tasks.push(this.newTaskText)
                 saveJson(TASKS_KEY, this.tasks)
                 this.newTaskText = ''

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,9 @@
 <template>
     <div id="app">
-        <input
-            type="text"
-            v-model.trim.lazy="newTaskText"
-            @keyup.enter="createTask"
-        />
-        <button @click="createTask">+</button>
+        <form @submit.prevent="createTask()">
+            <input type="text" v-model.trim.lazy="newTaskText" />
+            <button>+</button>
+        </form>
         <div v-for="task in tasks" :key="task.id">
             {{ task }}
         </div>

--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -1,16 +1,27 @@
+function expectTasksInStorageToEq(obj) {
+    cy.should(() => expect(localStorage.getItem('tasks')).to.eq(obj))
+}
+
 describe('CheckPoint', () => {
     beforeEach(() => {
         cy.visit('/')
     })
 
-    it('should add a task and save it', () => {
+    it('should create a task and save it', () => {
         const noteText = 'some random note'
 
         cy.get('input').type(noteText)
         cy.get('button').click()
         cy.contains('div', noteText)
+        expectTasksInStorageToEq(`["${noteText}"]`)
 
         cy.reload()
         cy.contains('div', noteText)
+        expectTasksInStorageToEq(`["${noteText}"]`)
+    })
+
+    it('should not create an empty task', () => {
+        cy.get('button').click()
+        expectTasksInStorageToEq(null)
     })
 })


### PR DESCRIPTION
An input event was not processed properly on CTRL+ENTER because of the `@keyup` handler. Wrap input and button elements into a form to get rid of this issue. Filter out an empty string input as a text for new tasks.