### PR TITLE
Tasks sorting

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,18 @@
                 <button data-cy="finish-task-btn" @click="finishTask(task)">
                     ✓
                 </button>
+                <button
+                    data-cy="move-task-up-btn"
+                    @click="shiftPosition(task, -1)"
+                >
+                    ↑
+                </button>
+                <button
+                    data-cy="move-task-down-btn"
+                    @click="shiftPosition(task, +1)"
+                >
+                    ↓
+                </button>
             </div>
         </div>
         ---
@@ -29,6 +41,8 @@
 </template>
 
 <script>
+    import Vue from 'vue'
+
     const TASKS_KEY = 'tasks'
 
     function task(text) {
@@ -74,11 +88,22 @@
                 task.isDone = false
                 this.saveTasks()
             },
+            shiftPosition(origTask, indexOffset) {
+                let origIndex = this.tasks.indexOf(origTask)
+                let newIndex = origIndex + indexOffset
+                if (newIndex >= this.activeTasks.length || newIndex < 0) return
+
+                let otherTask = this.tasks[newIndex]
+                Vue.set(this.tasks, origIndex, otherTask)
+                Vue.set(this.tasks, newIndex, origTask)
+                this.saveTasks()
+            },
             loadTasks() {
                 let json = localStorage.getItem(TASKS_KEY)
                 this.tasks = JSON.parse(json) || []
             },
             saveTasks() {
+                this.tasks = this.activeTasks.concat(this.doneTasks)
                 let json = JSON.stringify(this.tasks)
                 localStorage.setItem(TASKS_KEY, json)
             }


### PR DESCRIPTION
Add a button to move tasks up or down. This is applicable only to active tasks. Finished tasks are now sorted in order from the most recent to the oldest one.